### PR TITLE
fix(flutter): align default BFF port with FastAPI (8000)

### DIFF
--- a/clients/flutter/lib/config.dart
+++ b/clients/flutter/lib/config.dart
@@ -1,7 +1,7 @@
 /// Central configuration for the Flutter client.
 /// Override `bffBaseUrl` at build time with:
 /// `flutter run --dart-define=BFF_BASE_URL=https://your-bff/api/v1`
-const String kDefaultBffBaseUrl = 'http://localhost:8080/api/v1';
+const String kDefaultBffBaseUrl = 'http://localhost:8000/api/v1';
 
 const String bffBaseUrl = String.fromEnvironment(
   'BFF_BASE_URL',


### PR DESCRIPTION
Flutter default `kDefaultBffBaseUrl` pointed at `:8080`, but the FastAPI BFF listens on `:8000`. Running `flutter run` without `--dart-define` couldn't reach the BFF. Bumping default to `:8000` to match the README quick start.