### PR TITLE
feat(tanstack-start): named travellers with entitlements

### DIFF
--- a/clients/tanstack-start/src/components/checkout/BundleCard.tsx
+++ b/clients/tanstack-start/src/components/checkout/BundleCard.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { formatPrice } from "../../lib/format-price";
-import { partyLabel, type TravelParty } from "../../routes/offers";
+import { partyLabel, type TravelParty } from "../../lib/travel-party";
 import type { Offer } from "../../types/search";
 
 export interface OfferBundle {

--- a/clients/tanstack-start/src/components/checkout/BundleCard.tsx
+++ b/clients/tanstack-start/src/components/checkout/BundleCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { formatPrice } from "../../lib/format-price";
-import type { Offer, UserProfile } from "../../types/search";
+import { partyLabel, type TravelParty } from "../../routes/offers";
+import type { Offer } from "../../types/search";
 
 export interface OfferBundle {
 	groupKey: number | string;
@@ -11,23 +12,9 @@ export interface OfferBundle {
 	sequences: number[];
 }
 
-const AGE_GROUP_LABELS: Record<string, string> = {
-	adult: "Adult",
-	child: "Child",
-	youth: "Youth",
-	senior: "Senior",
-	infant: "Infant",
-	anyone: "Traveller",
-};
-
-function profileLabel(p: UserProfile): string {
-	const base = AGE_GROUP_LABELS[p.ageGroup ?? "anyone"] ?? p.id;
-	return p.count && p.count > 1 ? `${base} × ${p.count}` : base;
-}
-
 interface BundleCardProps {
 	bundle: OfferBundle;
-	profiles?: UserProfile[];
+	parties?: TravelParty[];
 	selected?: boolean;
 	onSelect?: () => void;
 }
@@ -102,7 +89,7 @@ export function buildBundles(offers: Offer[]): OfferBundle[] {
 
 export default function BundleCard({
 	bundle,
-	profiles = [],
+	parties = [],
 	selected = false,
 	onSelect,
 }: BundleCardProps) {
@@ -115,8 +102,8 @@ export default function BundleCard({
 
 	const offerCount = bundle.offers.length;
 
-	const bundleProfileIds = new Set(bundle.offers.flatMap(getOfferTravellerIds));
-	const coveredProfiles = profiles.filter((p) => bundleProfileIds.has(p.id));
+	const bundlePartyIds = new Set(bundle.offers.flatMap(getOfferTravellerIds));
+	const coveredParties = parties.filter((p) => bundlePartyIds.has(p.id));
 
 	return (
 		<label
@@ -190,9 +177,9 @@ export default function BundleCard({
 					</div>
 
 					{/* Traveller pills — only those covered by this bundle */}
-					{coveredProfiles.length > 0 && (
+					{coveredParties.length > 0 && (
 						<div className="mt-2 flex flex-wrap gap-1.5">
-							{coveredProfiles.map((p) => (
+							{coveredParties.map((p) => (
 								<span
 									key={p.id}
 									className="inline-flex items-center rounded-full px-2 py-0.5 text-xs"
@@ -202,7 +189,7 @@ export default function BundleCard({
 										border: "1px solid var(--wayfare-line)",
 									}}
 								>
-									{profileLabel(p)}
+									{partyLabel(p)}
 								</span>
 							))}
 						</div>
@@ -243,13 +230,13 @@ export default function BundleCard({
 									"Travel offer";
 								const price = offer.properties?.price;
 								const ids = getOfferTravellerIds(offer);
-								const offerProfiles = profiles.filter((p) =>
+								const offerParties = parties.filter((p) =>
 									ids.includes(p.id),
 								);
 
 								const travellerText =
-									offerProfiles.length > 0
-										? offerProfiles.map(profileLabel).join(", ")
+									offerParties.length > 0
+										? offerParties.map(partyLabel).join(", ")
 										: ids.length > 0
 											? `${ids.length} traveller${ids.length !== 1 ? "s" : ""}`
 											: null;

--- a/clients/tanstack-start/src/components/checkout/BundleCard.tsx
+++ b/clients/tanstack-start/src/components/checkout/BundleCard.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { formatPrice } from "../../lib/format-price";
-import type { IndividualTraveller, Offer } from "../../types/search";
+import type { Offer, UserProfile } from "../../types/search";
 
 export interface OfferBundle {
 	groupKey: number | string;
@@ -11,9 +11,23 @@ export interface OfferBundle {
 	sequences: number[];
 }
 
+const AGE_GROUP_LABELS: Record<string, string> = {
+	adult: "Adult",
+	child: "Child",
+	youth: "Youth",
+	senior: "Senior",
+	infant: "Infant",
+	anyone: "Traveller",
+};
+
+function profileLabel(p: UserProfile): string {
+	const base = AGE_GROUP_LABELS[p.ageGroup ?? "anyone"] ?? p.id;
+	return p.count && p.count > 1 ? `${base} × ${p.count}` : base;
+}
+
 interface BundleCardProps {
 	bundle: OfferBundle;
-	travellers?: IndividualTraveller[];
+	profiles?: UserProfile[];
 	selected?: boolean;
 	onSelect?: () => void;
 }
@@ -88,7 +102,7 @@ export function buildBundles(offers: Offer[]): OfferBundle[] {
 
 export default function BundleCard({
 	bundle,
-	travellers = [],
+	profiles = [],
 	selected = false,
 	onSelect,
 }: BundleCardProps) {
@@ -101,12 +115,8 @@ export default function BundleCard({
 
 	const offerCount = bundle.offers.length;
 
-	const bundleTravellerIds = new Set(
-		bundle.offers.flatMap(getOfferTravellerIds),
-	);
-	const coveredTravellers = travellers.filter((t) =>
-		bundleTravellerIds.has(t.id),
-	);
+	const bundleProfileIds = new Set(bundle.offers.flatMap(getOfferTravellerIds));
+	const coveredProfiles = profiles.filter((p) => bundleProfileIds.has(p.id));
 
 	return (
 		<label
@@ -180,11 +190,11 @@ export default function BundleCard({
 					</div>
 
 					{/* Traveller pills — only those covered by this bundle */}
-					{coveredTravellers.length > 0 && (
+					{coveredProfiles.length > 0 && (
 						<div className="mt-2 flex flex-wrap gap-1.5">
-							{coveredTravellers.map((t) => (
+							{coveredProfiles.map((p) => (
 								<span
-									key={t.id}
+									key={p.id}
 									className="inline-flex items-center rounded-full px-2 py-0.5 text-xs"
 									style={{
 										background: "var(--wayfare-bg)",
@@ -192,7 +202,7 @@ export default function BundleCard({
 										border: "1px solid var(--wayfare-line)",
 									}}
 								>
-									{t.age != null ? `${t.age} yrs` : t.id}
+									{profileLabel(p)}
 								</span>
 							))}
 						</div>
@@ -233,13 +243,13 @@ export default function BundleCard({
 									"Travel offer";
 								const price = offer.properties?.price;
 								const ids = getOfferTravellerIds(offer);
-								const offerTravellers = travellers.filter((t) =>
-									ids.includes(t.id),
+								const offerProfiles = profiles.filter((p) =>
+									ids.includes(p.id),
 								);
 
 								const travellerText =
-									offerTravellers.length > 0
-										? `${offerTravellers.length} traveller${offerTravellers.length !== 1 ? "s" : ""} (${offerTravellers.map((t) => (t.age != null ? `${t.age} yrs` : t.id)).join(", ")})`
+									offerProfiles.length > 0
+										? offerProfiles.map(profileLabel).join(", ")
 										: ids.length > 0
 											? `${ids.length} traveller${ids.length !== 1 ? "s" : ""}`
 											: null;

--- a/clients/tanstack-start/src/components/search/TravelerPicker.tsx
+++ b/clients/tanstack-start/src/components/search/TravelerPicker.tsx
@@ -1,184 +1,178 @@
 import { DownArrowIcon, UsersIcon } from "@entur/icons";
 import { useEffect, useRef, useState } from "react";
-import type {
-	Entitlement,
-	TravelerGroup,
-	TravelerIndividual,
-} from "../../context/search-form";
+import type { TravelerGroup, TravelerIndividual } from "../../context/search-form";
 
 const GROUPS: {
 	id: TravelerGroup["ageGroup"];
 	label: string;
-	minAge?: number;
-	maxAge?: number;
+	subtitle?: string;
+	// When true: per-person rows (age + name) always visible when count > 0, no expand toggle
+	perPerson?: boolean;
 }[] = [
-	{ id: "ADULT", label: "Adult", minAge: 18 },
-	{ id: "YOUTH", label: "Youth", minAge: 16, maxAge: 17 },
-	{ id: "CHILD", label: "Child", minAge: 6, maxAge: 15 },
-	{ id: "SENIOR", label: "Senior", minAge: 67 },
+	{ id: "ADULT", label: "Adult", subtitle: "18+ yrs" },
+	{ id: "YOUTH", label: "Youth", subtitle: "16–17 yrs" },
+	{ id: "CHILD", label: "Child", subtitle: "6–15 yrs" },
+	{ id: "SENIOR", label: "Senior", subtitle: "67+ yrs", perPerson: true },
+	{ id: "STUDENT", label: "Student", perPerson: true },
+	{ id: "MILITARY", label: "Military" },
 ];
 
-const ENTITLEMENT_OPTIONS: { value: Entitlement; label: string }[] = [
-	{ value: "STUDENT", label: "Student" },
-	{ value: "MILITARY", label: "Military" },
-];
+const ringStyle = {
+	"--tw-ring-color": "color-mix(in srgb, var(--wayfare-primary) 30%, transparent)",
+} as React.CSSProperties;
 
-const ENTITLEMENT_GROUPS: TravelerGroup["ageGroup"][] = [
-	"ADULT",
-	"YOUTH",
-	"SENIOR",
-];
+const inputStyle: React.CSSProperties = {
+	borderColor: "var(--wayfare-line)",
+	background: "var(--wayfare-bg)",
+	color: "var(--wayfare-text)",
+	...ringStyle,
+};
+
+const inputCls = "rounded-lg border px-2 py-1.5 text-xs outline-none focus:ring-1";
 
 interface TravelerPickerProps {
 	travelers: TravelerGroup[];
 	onChange: (travelers: TravelerGroup[]) => void;
 }
 
-export default function TravelerPicker({
-	travelers,
-	onChange,
-}: TravelerPickerProps) {
+export default function TravelerPicker({ travelers, onChange }: TravelerPickerProps) {
 	const [open, setOpen] = useState(false);
-	const [expandedId, setExpandedId] = useState<
-		TravelerGroup["ageGroup"] | null
-	>(null);
+	const [expandedId, setExpandedId] = useState<TravelerGroup["ageGroup"] | null>(null);
 	const containerRef = useRef<HTMLDivElement>(null);
 
 	const total = travelers.reduce((sum, t) => sum + t.count, 0);
-	const summary =
-		total === 0
-			? "Add travelers"
-			: `${total} traveler${total !== 1 ? "s" : ""}`;
+	const summary = total === 0 ? "Add travelers" : `${total} traveler${total !== 1 ? "s" : ""}`;
 
 	useEffect(() => {
-		function handlePointerDown(e: PointerEvent) {
-			if (
-				containerRef.current &&
-				!containerRef.current.contains(e.target as Node)
-			) {
+		function onPointerDown(e: PointerEvent) {
+			if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
 				setOpen(false);
 			}
 		}
-		document.addEventListener("pointerdown", handlePointerDown);
-		return () => document.removeEventListener("pointerdown", handlePointerDown);
+		document.addEventListener("pointerdown", onPointerDown);
+		return () => document.removeEventListener("pointerdown", onPointerDown);
 	}, []);
 
-	function getGroup(
-		ageGroup: TravelerGroup["ageGroup"],
-	): TravelerGroup | undefined {
-		return travelers.find((t) => t.ageGroup === ageGroup);
+	function getGroup(ag: TravelerGroup["ageGroup"]) {
+		return travelers.find((t) => t.ageGroup === ag);
 	}
 
-	function getCount(ageGroup: TravelerGroup["ageGroup"]): number {
-		return getGroup(ageGroup)?.count ?? 0;
+	function getCount(ag: TravelerGroup["ageGroup"]) {
+		return getGroup(ag)?.count ?? 0;
 	}
 
-	function updateGroup(
-		ageGroup: TravelerGroup["ageGroup"],
-		updates: Partial<TravelerGroup>,
-	) {
-		onChange(
-			travelers.map((t) =>
-				t.ageGroup === ageGroup ? { ...t, ...updates } : t,
-			),
-		);
+	function updateGroup(ag: TravelerGroup["ageGroup"], updates: Partial<TravelerGroup>) {
+		onChange(travelers.map((t) => (t.ageGroup === ag ? { ...t, ...updates } : t)));
 	}
 
-	function setCount(ageGroup: TravelerGroup["ageGroup"], count: number) {
+	function syncIndividuals(
+		existing: TravelerIndividual[] | undefined,
+		count: number,
+		perPerson: boolean,
+	): TravelerIndividual[] | undefined {
+		if (!perPerson && existing === undefined) return undefined;
+		const base = existing ?? [];
+		if (count > base.length) {
+			return [...base, ...Array<TravelerIndividual>(count - base.length).fill({})];
+		}
+		return base.slice(0, count);
+	}
+
+	function setCount(ag: TravelerGroup["ageGroup"], count: number) {
 		if (count < 0) return;
-		const existing = travelers.filter((t) => t.ageGroup !== ageGroup);
-		const meta = GROUPS.find((g) => g.id === ageGroup) ?? GROUPS[0];
+		const existing = travelers.filter((t) => t.ageGroup !== ag);
 		if (count === 0) {
-			if (expandedId === ageGroup) setExpandedId(null);
+			if (expandedId === ag) setExpandedId(null);
 			onChange(existing);
 			return;
 		}
-		const current = getGroup(ageGroup);
-		let individuals = current?.individuals;
-		if (individuals !== undefined) {
-			if (count > individuals.length) {
-				individuals = [
-					...individuals,
-					...Array<TravelerIndividual>(count - individuals.length).fill({}),
-				];
-			} else {
-				individuals = individuals.slice(0, count);
-			}
-		}
+		const meta = GROUPS.find((g) => g.id === ag)!;
+		const current = getGroup(ag);
 		onChange([
 			...existing,
 			{
-				id: ageGroup.toLowerCase(),
-				ageGroup,
+				id: ag.toLowerCase(),
+				ageGroup: ag,
 				count,
-				minAge: meta.minAge,
-				maxAge: meta.maxAge,
-				...(current?.entitlement != null
-					? { entitlement: current.entitlement }
-					: {}),
-				...(current?.profileAge != null
-					? { profileAge: current.profileAge }
-					: {}),
-				...(individuals !== undefined ? { individuals } : {}),
+				...(meta.subtitle ? {} : {}), // no minAge/maxAge for STUDENT/MILITARY
+				...(ag === "ADULT" ? { minAge: 18 } : {}),
+				...(ag === "YOUTH" ? { minAge: 16, maxAge: 17 } : {}),
+				...(ag === "CHILD" ? { minAge: 6, maxAge: 15 } : {}),
+				...(ag === "SENIOR" ? { minAge: 67 } : {}),
+				individuals: syncIndividuals(current?.individuals, count, !!meta.perPerson),
 			},
 		]);
 	}
 
-	function setEntitlement(
-		ageGroup: TravelerGroup["ageGroup"],
-		value: Entitlement | "",
-	) {
-		const updates: Partial<TravelerGroup> =
-			value === "" ? { entitlement: undefined } : { entitlement: value };
-		// Clear profileAge when switching away from entitlements that need it
-		if (
-			value !== "STUDENT" &&
-			ageGroup !== "SENIOR" &&
-			getGroup(ageGroup)?.profileAge != null
-		) {
-			updates.profileAge = undefined;
-		}
-		updateGroup(ageGroup, updates);
-	}
-
-	function setProfileAge(
-		ageGroup: TravelerGroup["ageGroup"],
-		raw: string,
-	) {
-		const age = raw === "" ? undefined : Number(raw);
-		updateGroup(ageGroup, { profileAge: age });
-	}
-
-	function toggleNamedMode(ageGroup: TravelerGroup["ageGroup"]) {
-		const group = getGroup(ageGroup);
+	function toggleNamedMode(ag: TravelerGroup["ageGroup"]) {
+		const group = getGroup(ag);
 		if (!group) return;
-		if (group.individuals !== undefined) {
-			updateGroup(ageGroup, { individuals: undefined });
-		} else {
-			updateGroup(ageGroup, {
-				individuals: Array<TravelerIndividual>(group.count).fill({}),
-			});
-		}
+		updateGroup(
+			ag,
+			group.individuals !== undefined
+				? { individuals: undefined }
+				: { individuals: Array<TravelerIndividual>(group.count).fill({}) },
+		);
 	}
 
 	function updateIndividual(
-		ageGroup: TravelerGroup["ageGroup"],
+		ag: TravelerGroup["ageGroup"],
 		index: number,
 		patch: Partial<TravelerIndividual>,
 	) {
-		const group = getGroup(ageGroup);
+		const group = getGroup(ag);
 		if (!group?.individuals) return;
-		const individuals = group.individuals.map((ind, i) =>
-			i === index ? { ...ind, ...patch } : ind,
-		);
-		updateGroup(ageGroup, { individuals });
+		updateGroup(ag, {
+			individuals: group.individuals.map((ind, i) =>
+				i === index ? { ...ind, ...patch } : ind,
+			),
+		});
 	}
 
-	const inputStyle = {
-		borderColor: "var(--wayfare-line)",
-		background: "var(--wayfare-bg)",
-		color: "var(--wayfare-text)",
-	};
+	function renderIndividualRows(ag: TravelerGroup["ageGroup"], showAge: boolean) {
+		const group = getGroup(ag);
+		if (!group?.individuals) return null;
+		return (
+			<div className="flex flex-col gap-2 pb-3 pl-1">
+				{group.individuals.map((person, i) => (
+					<div key={i} className="flex items-center gap-2">
+						<span
+							className="w-16 shrink-0 text-xs"
+							style={{ color: "var(--wayfare-text-secondary)" }}
+						>
+							{group.count === 1 ? "" : `Person ${i + 1}`}
+						</span>
+						{showAge && (
+							<input
+								type="number"
+								placeholder="Age"
+								min={1}
+								max={130}
+								value={person.age ?? ""}
+								onChange={(e) =>
+									updateIndividual(ag, i, {
+										age: e.target.value === "" ? undefined : Number(e.target.value),
+									})
+								}
+								className={`w-20 shrink-0 ${inputCls}`}
+								style={inputStyle}
+							/>
+						)}
+						<input
+							type="text"
+							placeholder="Name (optional)"
+							value={person.name ?? ""}
+							onChange={(e) =>
+								updateIndividual(ag, i, { name: e.target.value || undefined })
+							}
+							className={`min-w-0 flex-1 ${inputCls}`}
+							style={inputStyle}
+						/>
+					</div>
+				))}
+			</div>
+		);
+	}
 
 	return (
 		<div ref={containerRef} className="relative w-full">
@@ -189,22 +183,14 @@ export default function TravelerPicker({
 				style={{
 					borderColor: "var(--wayfare-line)",
 					background: "var(--wayfare-surface-strong)",
-					color:
-						total === 0
-							? "var(--wayfare-text-secondary)"
-							: "var(--wayfare-text)",
-					// @ts-expect-error - css custom prop
-					"--tw-ring-color":
-						"color-mix(in srgb, var(--wayfare-primary) 30%, transparent)",
+					color: total === 0 ? "var(--wayfare-text-secondary)" : "var(--wayfare-text)",
+					...ringStyle,
 				}}
 				aria-haspopup="dialog"
 				aria-expanded={open}
 			>
 				<span className="flex items-center gap-2">
-					<UsersIcon
-						aria-hidden="true"
-						style={{ color: "var(--wayfare-text-secondary)" }}
-					/>
+					<UsersIcon aria-hidden="true" style={{ color: "var(--wayfare-text-secondary)" }} />
 					{summary}
 				</span>
 				<DownArrowIcon
@@ -228,18 +214,13 @@ export default function TravelerPicker({
 						const count = getCount(group.id);
 						const current = getGroup(group.id);
 						const isExpanded = expandedId === group.id;
-						const showEntitlementRow = ENTITLEMENT_GROUPS.includes(group.id);
-						const shouldShowAgeRow =
-							current?.entitlement === "STUDENT" || group.id === "SENIOR";
 
 						return (
 							<div
 								key={group.id}
-								style={{
-									borderBottom: "1px solid var(--wayfare-line)",
-								}}
+								style={{ borderBottom: "1px solid var(--wayfare-line)" }}
 							>
-								{/* Main row */}
+								{/* Count row */}
 								<div className="flex items-center justify-between py-2.5">
 									<div>
 										<span
@@ -248,67 +229,55 @@ export default function TravelerPicker({
 										>
 											{group.label}
 										</span>
-										{(group.minAge !== undefined ||
-											group.maxAge !== undefined) && (
+										{group.subtitle && (
 											<span
 												className="ml-2 text-xs"
 												style={{ color: "var(--wayfare-text-secondary)" }}
 											>
-												{group.minAge && group.maxAge
-													? `${group.minAge}–${group.maxAge} yrs`
-													: group.minAge
-														? `${group.minAge}+ yrs`
-														: ""}
+												{group.subtitle}
 											</span>
 										)}
 									</div>
 									<div className="flex items-center gap-2">
-										<div className="flex items-center gap-2">
+										<button
+											type="button"
+											onClick={() => setCount(group.id, count - 1)}
+											disabled={count === 0}
+											aria-label={`Remove ${group.label}`}
+											className="flex h-7 w-7 items-center justify-center rounded-lg border text-sm font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-40"
+											style={{
+												borderColor: "var(--wayfare-line)",
+												color: "var(--wayfare-text)",
+												background: "transparent",
+											}}
+										>
+											−
+										</button>
+										<span
+											className="w-4 text-center text-sm font-semibold tabular-nums"
+											style={{ color: "var(--wayfare-text)" }}
+										>
+											{count}
+										</span>
+										<button
+											type="button"
+											onClick={() => setCount(group.id, count + 1)}
+											aria-label={`Add ${group.label}`}
+											className="flex h-7 w-7 items-center justify-center rounded-lg border text-sm font-semibold transition-colors"
+											style={{
+												borderColor: "var(--wayfare-line)",
+												color: "var(--wayfare-text)",
+												background: "transparent",
+											}}
+										>
+											+
+										</button>
+										{/* Expand toggle — only for non-perPerson groups */}
+										{!group.perPerson && count > 0 && (
 											<button
 												type="button"
-												onClick={() => setCount(group.id, count - 1)}
-												disabled={count === 0}
-												aria-label={`Remove ${group.label}`}
-												className="flex h-7 w-7 items-center justify-center rounded-lg border text-sm font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-40"
-												style={{
-													borderColor: "var(--wayfare-line)",
-													color: "var(--wayfare-text)",
-													background: "transparent",
-												}}
-											>
-												−
-											</button>
-											<span
-												className="w-4 text-center text-sm font-semibold tabular-nums"
-												style={{ color: "var(--wayfare-text)" }}
-											>
-												{count}
-											</span>
-											<button
-												type="button"
-												onClick={() => setCount(group.id, count + 1)}
-												aria-label={`Add ${group.label}`}
-												className="flex h-7 w-7 items-center justify-center rounded-lg border text-sm font-semibold transition-colors"
-												style={{
-													borderColor: "var(--wayfare-line)",
-													color: "var(--wayfare-text)",
-													background: "transparent",
-												}}
-											>
-												+
-											</button>
-										</div>
-										{count > 0 && (
-											<button
-												type="button"
-												onClick={() =>
-													setExpandedId(isExpanded ? null : group.id)
-												}
-												aria-label={
-													isExpanded
-														? `Collapse ${group.label} options`
-														: `Expand ${group.label} options`
-												}
+												onClick={() => setExpandedId(isExpanded ? null : group.id)}
+												aria-label={`${isExpanded ? "Collapse" : "Expand"} ${group.label} options`}
 												className="flex h-7 w-7 items-center justify-center rounded-lg border text-xs transition-colors"
 												style={{
 													borderColor: isExpanded
@@ -326,83 +295,16 @@ export default function TravelerPicker({
 									</div>
 								</div>
 
-								{/* Expanded panel */}
-								{isExpanded && count > 0 && (
+								{/* perPerson groups: always-visible individual rows */}
+								{group.perPerson && count > 0 &&
+									renderIndividualRows(group.id, true)}
+
+								{/* Non-perPerson groups: collapsible names panel */}
+								{!group.perPerson && isExpanded && count > 0 && (
 									<div className="mb-3 flex flex-col gap-3 pl-1">
-										{/* Entitlement selector */}
-										{showEntitlementRow && (
-											<div className="flex items-center gap-3">
-												<span
-													className="w-24 shrink-0 text-xs"
-													style={{ color: "var(--wayfare-text-secondary)" }}
-												>
-													Entitlement
-												</span>
-												<select
-													value={current?.entitlement ?? ""}
-													onChange={(e) =>
-														setEntitlement(
-															group.id,
-															e.target.value as Entitlement | "",
-														)
-													}
-													className="flex-1 rounded-lg border px-2 py-1.5 text-xs outline-none focus:ring-1"
-													style={{
-														...inputStyle,
-														// @ts-expect-error css custom prop
-														"--tw-ring-color":
-															"color-mix(in srgb, var(--wayfare-primary) 30%, transparent)",
-													}}
-												>
-													<option value="">None</option>
-													{ENTITLEMENT_OPTIONS.map((opt) => (
-														<option key={opt.value} value={opt.value}>
-															{opt.label}
-														</option>
-													))}
-												</select>
-											</div>
-										)}
-
-										{/* Age input (STUDENT or SENIOR anonymous profile) */}
-										{shouldShowAgeRow && (
-											<div className="flex items-center gap-3">
-												<span
-													className="w-24 shrink-0 text-xs"
-													style={{ color: "var(--wayfare-text-secondary)" }}
-												>
-													Age
-													<span
-														className="ml-1"
-														style={{ color: "var(--wayfare-text-secondary)", opacity: 0.6 }}
-													>
-														(optional)
-													</span>
-												</span>
-												<input
-													type="number"
-													min={1}
-													max={130}
-													placeholder="e.g. 25"
-													value={current?.profileAge ?? ""}
-													onChange={(e) =>
-														setProfileAge(group.id, e.target.value)
-													}
-													className="w-24 rounded-lg border px-2 py-1.5 text-xs outline-none focus:ring-1"
-													style={{
-														...inputStyle,
-														// @ts-expect-error css custom prop
-														"--tw-ring-color":
-															"color-mix(in srgb, var(--wayfare-primary) 30%, transparent)",
-													}}
-												/>
-											</div>
-										)}
-
-										{/* Named mode toggle */}
 										<div className="flex items-center gap-3">
 											<span
-												className="w-24 shrink-0 text-xs"
+												className="w-16 shrink-0 text-xs"
 												style={{ color: "var(--wayfare-text-secondary)" }}
 											>
 												Names
@@ -428,64 +330,8 @@ export default function TravelerPicker({
 													: "Add names"}
 											</button>
 										</div>
-
-										{/* Individual rows */}
-										{current?.individuals !== undefined && (
-											<div className="flex flex-col gap-2 pl-1">
-												{current.individuals.map((person, i) => (
-													<div
-														key={i}
-														className="flex items-center gap-2"
-													>
-														<span
-															className="w-16 shrink-0 text-xs"
-															style={{ color: "var(--wayfare-text-secondary)" }}
-														>
-															Person {i + 1}
-														</span>
-														<input
-															type="text"
-															placeholder="Name"
-															value={person.name ?? ""}
-															onChange={(e) =>
-																updateIndividual(group.id, i, {
-																	name: e.target.value || undefined,
-																})
-															}
-															className="min-w-0 flex-1 rounded-lg border px-2 py-1.5 text-xs outline-none focus:ring-1"
-															style={{
-																...inputStyle,
-																// @ts-expect-error css custom prop
-																"--tw-ring-color":
-																	"color-mix(in srgb, var(--wayfare-primary) 30%, transparent)",
-															}}
-														/>
-														<input
-															type="number"
-															placeholder="Age"
-															min={1}
-															max={130}
-															value={person.age ?? ""}
-															onChange={(e) =>
-																updateIndividual(group.id, i, {
-																	age:
-																		e.target.value === ""
-																			? undefined
-																			: Number(e.target.value),
-																})
-															}
-															className="w-16 shrink-0 rounded-lg border px-2 py-1.5 text-xs outline-none focus:ring-1"
-															style={{
-																...inputStyle,
-																// @ts-expect-error css custom prop
-																"--tw-ring-color":
-																	"color-mix(in srgb, var(--wayfare-primary) 30%, transparent)",
-															}}
-														/>
-													</div>
-												))}
-											</div>
-										)}
+										{current?.individuals !== undefined &&
+											renderIndividualRows(group.id, false)}
 									</div>
 								)}
 							</div>

--- a/clients/tanstack-start/src/components/search/TravelerPicker.tsx
+++ b/clients/tanstack-start/src/components/search/TravelerPicker.tsx
@@ -73,7 +73,7 @@ export default function TravelerPicker({ travelers, onChange }: TravelerPickerPr
 		if (!perPerson && existing === undefined) return undefined;
 		const base = existing ?? [];
 		if (count > base.length) {
-			return [...base, ...Array<TravelerIndividual>(count - base.length).fill({})];
+			return [...base, ...Array.from({ length: count - base.length }, (): TravelerIndividual => ({}))];
 		}
 		return base.slice(0, count);
 	}
@@ -94,8 +94,7 @@ export default function TravelerPicker({ travelers, onChange }: TravelerPickerPr
 				id: ag.toLowerCase(),
 				ageGroup: ag,
 				count,
-				...(meta.subtitle ? {} : {}), // no minAge/maxAge for STUDENT/MILITARY
-				...(ag === "ADULT" ? { minAge: 18 } : {}),
+...(ag === "ADULT" ? { minAge: 18 } : {}),
 				...(ag === "YOUTH" ? { minAge: 16, maxAge: 17 } : {}),
 				...(ag === "CHILD" ? { minAge: 6, maxAge: 15 } : {}),
 				...(ag === "SENIOR" ? { minAge: 67 } : {}),
@@ -111,7 +110,7 @@ export default function TravelerPicker({ travelers, onChange }: TravelerPickerPr
 			ag,
 			group.individuals !== undefined
 				? { individuals: undefined }
-				: { individuals: Array<TravelerIndividual>(group.count).fill({}) },
+				: { individuals: Array.from({ length: group.count }, (): TravelerIndividual => ({})) },
 		);
 	}
 

--- a/clients/tanstack-start/src/components/search/TravelerPicker.tsx
+++ b/clients/tanstack-start/src/components/search/TravelerPicker.tsx
@@ -1,6 +1,10 @@
 import { DownArrowIcon, UsersIcon } from "@entur/icons";
 import { useEffect, useRef, useState } from "react";
-import type { TravelerGroup } from "../../context/search-form";
+import type {
+	Entitlement,
+	TravelerGroup,
+	TravelerIndividual,
+} from "../../context/search-form";
 
 const GROUPS: {
 	id: TravelerGroup["ageGroup"];
@@ -14,6 +18,17 @@ const GROUPS: {
 	{ id: "SENIOR", label: "Senior", minAge: 67 },
 ];
 
+const ENTITLEMENT_OPTIONS: { value: Entitlement; label: string }[] = [
+	{ value: "STUDENT", label: "Student" },
+	{ value: "MILITARY", label: "Military" },
+];
+
+const ENTITLEMENT_GROUPS: TravelerGroup["ageGroup"][] = [
+	"ADULT",
+	"YOUTH",
+	"SENIOR",
+];
+
 interface TravelerPickerProps {
 	travelers: TravelerGroup[];
 	onChange: (travelers: TravelerGroup[]) => void;
@@ -24,6 +39,9 @@ export default function TravelerPicker({
 	onChange,
 }: TravelerPickerProps) {
 	const [open, setOpen] = useState(false);
+	const [expandedId, setExpandedId] = useState<
+		TravelerGroup["ageGroup"] | null
+	>(null);
 	const containerRef = useRef<HTMLDivElement>(null);
 
 	const total = travelers.reduce((sum, t) => sum + t.count, 0);
@@ -32,7 +50,6 @@ export default function TravelerPicker({
 			? "Add travelers"
 			: `${total} traveler${total !== 1 ? "s" : ""}`;
 
-	// Close on outside click
 	useEffect(() => {
 		function handlePointerDown(e: PointerEvent) {
 			if (
@@ -46,29 +63,122 @@ export default function TravelerPicker({
 		return () => document.removeEventListener("pointerdown", handlePointerDown);
 	}, []);
 
-	function getCount(ageGroup: TravelerGroup["ageGroup"]) {
-		return travelers.find((t) => t.ageGroup === ageGroup)?.count ?? 0;
+	function getGroup(
+		ageGroup: TravelerGroup["ageGroup"],
+	): TravelerGroup | undefined {
+		return travelers.find((t) => t.ageGroup === ageGroup);
+	}
+
+	function getCount(ageGroup: TravelerGroup["ageGroup"]): number {
+		return getGroup(ageGroup)?.count ?? 0;
+	}
+
+	function updateGroup(
+		ageGroup: TravelerGroup["ageGroup"],
+		updates: Partial<TravelerGroup>,
+	) {
+		onChange(
+			travelers.map((t) =>
+				t.ageGroup === ageGroup ? { ...t, ...updates } : t,
+			),
+		);
 	}
 
 	function setCount(ageGroup: TravelerGroup["ageGroup"], count: number) {
 		if (count < 0) return;
 		const existing = travelers.filter((t) => t.ageGroup !== ageGroup);
-		const group = GROUPS.find((g) => g.id === ageGroup) ?? GROUPS[0];
+		const meta = GROUPS.find((g) => g.id === ageGroup) ?? GROUPS[0];
 		if (count === 0) {
+			if (expandedId === ageGroup) setExpandedId(null);
 			onChange(existing);
+			return;
+		}
+		const current = getGroup(ageGroup);
+		let individuals = current?.individuals;
+		if (individuals !== undefined) {
+			if (count > individuals.length) {
+				individuals = [
+					...individuals,
+					...Array<TravelerIndividual>(count - individuals.length).fill({}),
+				];
+			} else {
+				individuals = individuals.slice(0, count);
+			}
+		}
+		onChange([
+			...existing,
+			{
+				id: ageGroup.toLowerCase(),
+				ageGroup,
+				count,
+				minAge: meta.minAge,
+				maxAge: meta.maxAge,
+				...(current?.entitlement != null
+					? { entitlement: current.entitlement }
+					: {}),
+				...(current?.profileAge != null
+					? { profileAge: current.profileAge }
+					: {}),
+				...(individuals !== undefined ? { individuals } : {}),
+			},
+		]);
+	}
+
+	function setEntitlement(
+		ageGroup: TravelerGroup["ageGroup"],
+		value: Entitlement | "",
+	) {
+		const updates: Partial<TravelerGroup> =
+			value === "" ? { entitlement: undefined } : { entitlement: value };
+		// Clear profileAge when switching away from entitlements that need it
+		if (
+			value !== "STUDENT" &&
+			ageGroup !== "SENIOR" &&
+			getGroup(ageGroup)?.profileAge != null
+		) {
+			updates.profileAge = undefined;
+		}
+		updateGroup(ageGroup, updates);
+	}
+
+	function setProfileAge(
+		ageGroup: TravelerGroup["ageGroup"],
+		raw: string,
+	) {
+		const age = raw === "" ? undefined : Number(raw);
+		updateGroup(ageGroup, { profileAge: age });
+	}
+
+	function toggleNamedMode(ageGroup: TravelerGroup["ageGroup"]) {
+		const group = getGroup(ageGroup);
+		if (!group) return;
+		if (group.individuals !== undefined) {
+			updateGroup(ageGroup, { individuals: undefined });
 		} else {
-			onChange([
-				...existing,
-				{
-					id: ageGroup.toLowerCase(),
-					ageGroup,
-					count,
-					minAge: group.minAge,
-					maxAge: group.maxAge,
-				},
-			]);
+			updateGroup(ageGroup, {
+				individuals: Array<TravelerIndividual>(group.count).fill({}),
+			});
 		}
 	}
+
+	function updateIndividual(
+		ageGroup: TravelerGroup["ageGroup"],
+		index: number,
+		patch: Partial<TravelerIndividual>,
+	) {
+		const group = getGroup(ageGroup);
+		if (!group?.individuals) return;
+		const individuals = group.individuals.map((ind, i) =>
+			i === index ? { ...ind, ...patch } : ind,
+		);
+		updateGroup(ageGroup, { individuals });
+	}
+
+	const inputStyle = {
+		borderColor: "var(--wayfare-line)",
+		background: "var(--wayfare-bg)",
+		color: "var(--wayfare-text)",
+	};
 
 	return (
 		<div ref={containerRef} className="relative w-full">
@@ -106,7 +216,7 @@ export default function TravelerPicker({
 
 			{open && (
 				<div
-					className="absolute z-50 mt-1 w-full min-w-[260px] rounded-xl border p-4 shadow-lg"
+					className="absolute z-50 mt-1 w-full min-w-[300px] rounded-xl border p-4 shadow-lg"
 					style={{
 						borderColor: "var(--wayfare-line)",
 						background: "var(--wayfare-surface-strong)",
@@ -114,71 +224,274 @@ export default function TravelerPicker({
 					role="dialog"
 					aria-label="Select travelers"
 				>
-					{GROUPS.map((group) => (
-						<div
-							key={group.id}
-							className="flex items-center justify-between py-2.5"
-							style={{
-								borderBottom: "1px solid var(--wayfare-line)",
-							}}
-						>
-							<div>
-								<span
-									className="text-sm font-medium"
-									style={{ color: "var(--wayfare-text)" }}
-								>
-									{group.label}
-								</span>
-								{(group.minAge !== undefined || group.maxAge !== undefined) && (
-									<span
-										className="ml-2 text-xs"
-										style={{ color: "var(--wayfare-text-secondary)" }}
-									>
-										{group.minAge && group.maxAge
-											? `${group.minAge}–${group.maxAge} yrs`
-											: group.minAge
-												? `${group.minAge}+ yrs`
-												: ""}
-									</span>
+					{GROUPS.map((group) => {
+						const count = getCount(group.id);
+						const current = getGroup(group.id);
+						const isExpanded = expandedId === group.id;
+						const showEntitlementRow = ENTITLEMENT_GROUPS.includes(group.id);
+						const shouldShowAgeRow =
+							current?.entitlement === "STUDENT" || group.id === "SENIOR";
+
+						return (
+							<div
+								key={group.id}
+								style={{
+									borderBottom: "1px solid var(--wayfare-line)",
+								}}
+							>
+								{/* Main row */}
+								<div className="flex items-center justify-between py-2.5">
+									<div>
+										<span
+											className="text-sm font-medium"
+											style={{ color: "var(--wayfare-text)" }}
+										>
+											{group.label}
+										</span>
+										{(group.minAge !== undefined ||
+											group.maxAge !== undefined) && (
+											<span
+												className="ml-2 text-xs"
+												style={{ color: "var(--wayfare-text-secondary)" }}
+											>
+												{group.minAge && group.maxAge
+													? `${group.minAge}–${group.maxAge} yrs`
+													: group.minAge
+														? `${group.minAge}+ yrs`
+														: ""}
+											</span>
+										)}
+									</div>
+									<div className="flex items-center gap-2">
+										<div className="flex items-center gap-2">
+											<button
+												type="button"
+												onClick={() => setCount(group.id, count - 1)}
+												disabled={count === 0}
+												aria-label={`Remove ${group.label}`}
+												className="flex h-7 w-7 items-center justify-center rounded-lg border text-sm font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-40"
+												style={{
+													borderColor: "var(--wayfare-line)",
+													color: "var(--wayfare-text)",
+													background: "transparent",
+												}}
+											>
+												−
+											</button>
+											<span
+												className="w-4 text-center text-sm font-semibold tabular-nums"
+												style={{ color: "var(--wayfare-text)" }}
+											>
+												{count}
+											</span>
+											<button
+												type="button"
+												onClick={() => setCount(group.id, count + 1)}
+												aria-label={`Add ${group.label}`}
+												className="flex h-7 w-7 items-center justify-center rounded-lg border text-sm font-semibold transition-colors"
+												style={{
+													borderColor: "var(--wayfare-line)",
+													color: "var(--wayfare-text)",
+													background: "transparent",
+												}}
+											>
+												+
+											</button>
+										</div>
+										{count > 0 && (
+											<button
+												type="button"
+												onClick={() =>
+													setExpandedId(isExpanded ? null : group.id)
+												}
+												aria-label={
+													isExpanded
+														? `Collapse ${group.label} options`
+														: `Expand ${group.label} options`
+												}
+												className="flex h-7 w-7 items-center justify-center rounded-lg border text-xs transition-colors"
+												style={{
+													borderColor: isExpanded
+														? "var(--wayfare-primary)"
+														: "var(--wayfare-line)",
+													color: isExpanded
+														? "var(--wayfare-primary)"
+														: "var(--wayfare-text-secondary)",
+													background: "transparent",
+												}}
+											>
+												{isExpanded ? "▴" : "▾"}
+											</button>
+										)}
+									</div>
+								</div>
+
+								{/* Expanded panel */}
+								{isExpanded && count > 0 && (
+									<div className="mb-3 flex flex-col gap-3 pl-1">
+										{/* Entitlement selector */}
+										{showEntitlementRow && (
+											<div className="flex items-center gap-3">
+												<span
+													className="w-24 shrink-0 text-xs"
+													style={{ color: "var(--wayfare-text-secondary)" }}
+												>
+													Entitlement
+												</span>
+												<select
+													value={current?.entitlement ?? ""}
+													onChange={(e) =>
+														setEntitlement(
+															group.id,
+															e.target.value as Entitlement | "",
+														)
+													}
+													className="flex-1 rounded-lg border px-2 py-1.5 text-xs outline-none focus:ring-1"
+													style={{
+														...inputStyle,
+														// @ts-expect-error css custom prop
+														"--tw-ring-color":
+															"color-mix(in srgb, var(--wayfare-primary) 30%, transparent)",
+													}}
+												>
+													<option value="">None</option>
+													{ENTITLEMENT_OPTIONS.map((opt) => (
+														<option key={opt.value} value={opt.value}>
+															{opt.label}
+														</option>
+													))}
+												</select>
+											</div>
+										)}
+
+										{/* Age input (STUDENT or SENIOR anonymous profile) */}
+										{shouldShowAgeRow && (
+											<div className="flex items-center gap-3">
+												<span
+													className="w-24 shrink-0 text-xs"
+													style={{ color: "var(--wayfare-text-secondary)" }}
+												>
+													Age
+													<span
+														className="ml-1"
+														style={{ color: "var(--wayfare-text-secondary)", opacity: 0.6 }}
+													>
+														(optional)
+													</span>
+												</span>
+												<input
+													type="number"
+													min={1}
+													max={130}
+													placeholder="e.g. 25"
+													value={current?.profileAge ?? ""}
+													onChange={(e) =>
+														setProfileAge(group.id, e.target.value)
+													}
+													className="w-24 rounded-lg border px-2 py-1.5 text-xs outline-none focus:ring-1"
+													style={{
+														...inputStyle,
+														// @ts-expect-error css custom prop
+														"--tw-ring-color":
+															"color-mix(in srgb, var(--wayfare-primary) 30%, transparent)",
+													}}
+												/>
+											</div>
+										)}
+
+										{/* Named mode toggle */}
+										<div className="flex items-center gap-3">
+											<span
+												className="w-24 shrink-0 text-xs"
+												style={{ color: "var(--wayfare-text-secondary)" }}
+											>
+												Names
+											</span>
+											<button
+												type="button"
+												onClick={() => toggleNamedMode(group.id)}
+												className="rounded-lg border px-2.5 py-1 text-xs font-medium transition-colors"
+												style={{
+													borderColor:
+														current?.individuals !== undefined
+															? "var(--wayfare-primary)"
+															: "var(--wayfare-line)",
+													color:
+														current?.individuals !== undefined
+															? "var(--wayfare-primary)"
+															: "var(--wayfare-text-secondary)",
+													background: "transparent",
+												}}
+											>
+												{current?.individuals !== undefined
+													? "Remove names"
+													: "Add names"}
+											</button>
+										</div>
+
+										{/* Individual rows */}
+										{current?.individuals !== undefined && (
+											<div className="flex flex-col gap-2 pl-1">
+												{current.individuals.map((person, i) => (
+													<div
+														key={i}
+														className="flex items-center gap-2"
+													>
+														<span
+															className="w-16 shrink-0 text-xs"
+															style={{ color: "var(--wayfare-text-secondary)" }}
+														>
+															Person {i + 1}
+														</span>
+														<input
+															type="text"
+															placeholder="Name"
+															value={person.name ?? ""}
+															onChange={(e) =>
+																updateIndividual(group.id, i, {
+																	name: e.target.value || undefined,
+																})
+															}
+															className="min-w-0 flex-1 rounded-lg border px-2 py-1.5 text-xs outline-none focus:ring-1"
+															style={{
+																...inputStyle,
+																// @ts-expect-error css custom prop
+																"--tw-ring-color":
+																	"color-mix(in srgb, var(--wayfare-primary) 30%, transparent)",
+															}}
+														/>
+														<input
+															type="number"
+															placeholder="Age"
+															min={1}
+															max={130}
+															value={person.age ?? ""}
+															onChange={(e) =>
+																updateIndividual(group.id, i, {
+																	age:
+																		e.target.value === ""
+																			? undefined
+																			: Number(e.target.value),
+																})
+															}
+															className="w-16 shrink-0 rounded-lg border px-2 py-1.5 text-xs outline-none focus:ring-1"
+															style={{
+																...inputStyle,
+																// @ts-expect-error css custom prop
+																"--tw-ring-color":
+																	"color-mix(in srgb, var(--wayfare-primary) 30%, transparent)",
+															}}
+														/>
+													</div>
+												))}
+											</div>
+										)}
+									</div>
 								)}
 							</div>
-							<div className="flex items-center gap-3">
-								<button
-									type="button"
-									onClick={() => setCount(group.id, getCount(group.id) - 1)}
-									disabled={getCount(group.id) === 0}
-									aria-label={`Remove ${group.label}`}
-									className="flex h-7 w-7 items-center justify-center rounded-lg border text-sm font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-40"
-									style={{
-										borderColor: "var(--wayfare-line)",
-										color: "var(--wayfare-text)",
-										background: "transparent",
-									}}
-								>
-									−
-								</button>
-								<span
-									className="w-4 text-center text-sm font-semibold tabular-nums"
-									style={{ color: "var(--wayfare-text)" }}
-								>
-									{getCount(group.id)}
-								</span>
-								<button
-									type="button"
-									onClick={() => setCount(group.id, getCount(group.id) + 1)}
-									aria-label={`Add ${group.label}`}
-									className="flex h-7 w-7 items-center justify-center rounded-lg border text-sm font-semibold transition-colors"
-									style={{
-										borderColor: "var(--wayfare-line)",
-										color: "var(--wayfare-text)",
-										background: "transparent",
-									}}
-								>
-									+
-								</button>
-							</div>
-						</div>
-					))}
+						);
+					})}
+
 					<button
 						type="button"
 						onClick={() => setOpen(false)}

--- a/clients/tanstack-start/src/components/ui/Button.tsx
+++ b/clients/tanstack-start/src/components/ui/Button.tsx
@@ -46,6 +46,7 @@ export default function Button({
 	return (
 		<button
 			type="button"
+			suppressHydrationWarning
 			disabled={disabled || loading}
 			className={[base, variantClass, fluid ? "w-full" : "", className]
 				.filter(Boolean)

--- a/clients/tanstack-start/src/context/search-form.tsx
+++ b/clients/tanstack-start/src/context/search-form.tsx
@@ -1,8 +1,6 @@
 import { createContext, useContext, useEffect, useReducer } from "react";
 import type { PlaceReference } from "../types/common";
 
-export type Entitlement = "STUDENT" | "MILITARY";
-
 export interface TravelerIndividual {
 	name?: string;
 	age?: number;
@@ -10,12 +8,10 @@ export interface TravelerIndividual {
 
 export interface TravelerGroup {
 	id: string;
-	ageGroup: "ADULT" | "CHILD" | "YOUTH" | "SENIOR" | "INFANT";
+	ageGroup: "ADULT" | "CHILD" | "YOUTH" | "SENIOR" | "INFANT" | "STUDENT" | "MILITARY";
 	count: number;
 	minAge?: number;
 	maxAge?: number;
-	entitlement?: Entitlement;
-	profileAge?: number;
 	individuals?: TravelerIndividual[];
 }
 

--- a/clients/tanstack-start/src/context/search-form.tsx
+++ b/clients/tanstack-start/src/context/search-form.tsx
@@ -1,12 +1,22 @@
 import { createContext, useContext, useEffect, useReducer } from "react";
 import type { PlaceReference } from "../types/common";
 
+export type Entitlement = "STUDENT" | "MILITARY";
+
+export interface TravelerIndividual {
+	name?: string;
+	age?: number;
+}
+
 export interface TravelerGroup {
 	id: string;
 	ageGroup: "ADULT" | "CHILD" | "YOUTH" | "SENIOR" | "INFANT";
 	count: number;
 	minAge?: number;
 	maxAge?: number;
+	entitlement?: Entitlement;
+	profileAge?: number;
+	individuals?: TravelerIndividual[];
 }
 
 export type SearchType = "zone" | "stop" | "trip";

--- a/clients/tanstack-start/src/lib/search-session.ts
+++ b/clients/tanstack-start/src/lib/search-session.ts
@@ -1,6 +1,6 @@
 import type { SearchType } from "../context/search-form";
 import type { PlaceReference } from "../types/common";
-import type { IndividualTraveller, OfferCollection } from "../types/search";
+import type { OfferCollection, UserProfile } from "../types/search";
 
 const OFFER_COLLECTION_KEY = "offerCollection";
 const SEARCH_CONTEXT_KEY = "searchContext";
@@ -10,7 +10,7 @@ export interface SearchContext {
 	to: PlaceReference;
 	travelDate: string;
 	searchType: SearchType;
-	travellers?: IndividualTraveller[];
+	profiles?: UserProfile[];
 }
 
 interface SearchSession {

--- a/clients/tanstack-start/src/lib/search-session.ts
+++ b/clients/tanstack-start/src/lib/search-session.ts
@@ -1,6 +1,6 @@
 import type { SearchType } from "../context/search-form";
 import type { PlaceReference } from "../types/common";
-import type { OfferCollection, UserProfile } from "../types/search";
+import type { IndividualTraveller, OfferCollection, UserProfile } from "../types/search";
 
 const OFFER_COLLECTION_KEY = "offerCollection";
 const SEARCH_CONTEXT_KEY = "searchContext";
@@ -11,6 +11,7 @@ export interface SearchContext {
 	travelDate: string;
 	searchType: SearchType;
 	profiles?: UserProfile[];
+	travellers?: IndividualTraveller[];
 }
 
 interface SearchSession {

--- a/clients/tanstack-start/src/lib/travel-party.ts
+++ b/clients/tanstack-start/src/lib/travel-party.ts
@@ -1,0 +1,27 @@
+import type { IndividualTraveller, UserProfile } from "../types/search";
+
+export type TravelParty = UserProfile | IndividualTraveller;
+
+const AGE_GROUP_LABELS: Record<string, string> = {
+	ADULT: "Adult",
+	CHILD: "Child",
+	YOUTH: "Youth",
+	SENIOR: "Senior",
+	INFANT: "Infant",
+	ANYONE: "Traveller",
+};
+
+export function partyLabel(p: TravelParty): string {
+	if (p.type === "user_profile") {
+		const entitlements = p.entitlements?.entitlementsGiven?.map((e) => e.entitlementType) ?? [];
+		const base = (p.ageGroup && AGE_GROUP_LABELS[p.ageGroup]) ?? entitlements[0] ?? p.id;
+		return p.count && p.count > 1 ? `${base} × ${p.count}` : base;
+	}
+	if (p.fullName) return p.fullName;
+	const entitlements = p.entitlements?.entitlementsGiven?.map((e) => e.entitlementType) ?? [];
+	if (entitlements.length > 0) {
+		const label = entitlements.join(", ");
+		return p.age != null ? `${label} (${p.age} yrs)` : label;
+	}
+	return p.age != null ? `${p.age} yrs` : p.id;
+}

--- a/clients/tanstack-start/src/routes/index.tsx
+++ b/clients/tanstack-start/src/routes/index.tsx
@@ -11,7 +11,7 @@ import { SearchFormProvider, useSearchForm } from "../context/search-form";
 import { useSearchOffers } from "../hooks/use-search-offers";
 import { useTripPlanner } from "../hooks/use-trip-planner";
 import { writeSearchSession } from "../lib/search-session";
-import type { TripPatternLeg } from "../types/search";
+import type { TripPatternLeg, UserProfile } from "../types/search";
 import type { TripPattern } from "../types/trip-planner";
 
 export const Route = createFileRoute("/")({ component: SearchPage });
@@ -24,22 +24,15 @@ function SearchPage() {
 	);
 }
 
-function buildTravellers(travelers: TravelerGroup[]) {
-	return travelers.flatMap((t, i) =>
-		Array.from({ length: t.count }, (_, j) => ({
-			id: `t${i}_${j}`,
-			type: "individual_traveller" as const,
-			age:
-				t.minAge ??
-				(t.ageGroup === "ADULT"
-					? 30
-					: t.ageGroup === "CHILD"
-						? 10
-						: t.ageGroup === "SENIOR"
-							? 70
-							: 16),
-		})),
-	);
+function buildProfiles(travelers: TravelerGroup[]): UserProfile[] {
+	return travelers.map((t) => ({
+		id: t.id,
+		type: "user_profile" as const,
+		count: t.count,
+		ageGroup: t.ageGroup.toLowerCase() as UserProfile["ageGroup"],
+		...(t.minAge != null ? { minimumAge: t.minAge } : {}),
+		...(t.maxAge != null ? { maximumAge: t.maxAge } : {}),
+	}));
 }
 
 function SearchScreen() {
@@ -65,12 +58,12 @@ function SearchScreen() {
 			return;
 		}
 
-		const travellers = buildTravellers(state.travelers);
+		const profiles = buildProfiles(state.travelers);
 
 		const result = await mutateAsync({
 			inputs: {
 				type: "search_offer",
-				travellers,
+				profiles,
 				specification: {
 					from,
 					to,
@@ -84,7 +77,7 @@ function SearchScreen() {
 			to,
 			travelDate,
 			searchType,
-			travellers,
+			profiles,
 		});
 		navigate({ to: "/offers" });
 	}
@@ -95,7 +88,7 @@ function SearchScreen() {
 		const to = state.to;
 		const travelDate = state.travelDate;
 		const searchType = state.searchType;
-		const travellers = buildTravellers(state.travelers);
+		const profiles = buildProfiles(state.travelers);
 
 		const omsaPattern: TripPatternLeg[] = pattern.legs.flatMap((leg) => {
 			if (!leg.serviceJourney) return [];
@@ -116,7 +109,7 @@ function SearchScreen() {
 		const result = await mutateAsync({
 			inputs: {
 				type: "search_offer",
-				travellers,
+				profiles,
 				pattern: omsaPattern,
 			},
 		});
@@ -126,7 +119,7 @@ function SearchScreen() {
 			to,
 			travelDate,
 			searchType,
-			travellers,
+			profiles,
 		});
 		navigate({ to: "/offers" });
 	}

--- a/clients/tanstack-start/src/routes/index.tsx
+++ b/clients/tanstack-start/src/routes/index.tsx
@@ -39,7 +39,7 @@ function buildRequest(travelers: TravelerGroup[]): {
 					? "MILITARY"
 					: undefined;
 		const entitlements = entitlementType
-			? { entitlements: { entitlementsGiven: [{ type: "entitlement", entitlementType }] } }
+			? { entitlements: { entitlementsGiven: [{ type: "entitlement" as const, entitlementType }] } }
 			: {};
 		// STUDENT and MILITARY don't map to a UserProfile ageGroup
 		const profileAgeGroup =

--- a/clients/tanstack-start/src/routes/index.tsx
+++ b/clients/tanstack-start/src/routes/index.tsx
@@ -39,7 +39,7 @@ function buildRequest(travelers: TravelerGroup[]): {
 					? "MILITARY"
 					: undefined;
 		const entitlements = entitlementType
-			? { entitlements: { entitlementsGiven: [{ entitlementType }] } }
+			? { entitlements: { entitlementsGiven: [{ type: "entitlement", entitlementType }] } }
 			: {};
 		// STUDENT and MILITARY don't map to a UserProfile ageGroup
 		const profileAgeGroup =

--- a/clients/tanstack-start/src/routes/index.tsx
+++ b/clients/tanstack-start/src/routes/index.tsx
@@ -54,7 +54,7 @@ function buildRequest(travelers: TravelerGroup[]): {
 					id: `${t.id}_anon`,
 					type: "user_profile",
 					count: unnamedCount,
-					ageGroup: t.ageGroup.toLowerCase() as UserProfile["ageGroup"],
+					ageGroup: t.ageGroup,
 					...(t.minAge != null ? { minimumAge: t.minAge } : {}),
 					...(t.maxAge != null ? { maximumAge: t.maxAge } : {}),
 					...entitlements,
@@ -66,7 +66,7 @@ function buildRequest(travelers: TravelerGroup[]): {
 				id: t.id,
 				type: "user_profile",
 				count: t.count,
-				ageGroup: t.ageGroup.toLowerCase() as UserProfile["ageGroup"],
+				ageGroup: t.ageGroup,
 				...(age != null
 					? { minimumAge: age, maximumAge: age }
 					: {

--- a/clients/tanstack-start/src/routes/index.tsx
+++ b/clients/tanstack-start/src/routes/index.tsx
@@ -32,9 +32,20 @@ function buildRequest(travelers: TravelerGroup[]): {
 	const travellers: IndividualTraveller[] = [];
 
 	for (const t of travelers) {
-		const entitlements = t.entitlement
-			? { entitlements: { entitlementsGiven: [{ entitlementType: t.entitlement }] } }
+		const entitlementType =
+			t.ageGroup === "STUDENT"
+				? "STUDENT"
+				: t.ageGroup === "MILITARY"
+					? "MILITARY"
+					: undefined;
+		const entitlements = entitlementType
+			? { entitlements: { entitlementsGiven: [{ entitlementType }] } }
 			: {};
+		// STUDENT and MILITARY don't map to a UserProfile ageGroup
+		const profileAgeGroup =
+			t.ageGroup !== "STUDENT" && t.ageGroup !== "MILITARY"
+				? t.ageGroup
+				: undefined;
 
 		const named = t.individuals?.filter((i) => i.name || i.age != null) ?? [];
 
@@ -54,25 +65,20 @@ function buildRequest(travelers: TravelerGroup[]): {
 					id: `${t.id}_anon`,
 					type: "user_profile",
 					count: unnamedCount,
-					ageGroup: t.ageGroup,
+					...(profileAgeGroup != null ? { ageGroup: profileAgeGroup } : {}),
 					...(t.minAge != null ? { minimumAge: t.minAge } : {}),
 					...(t.maxAge != null ? { maximumAge: t.maxAge } : {}),
 					...entitlements,
 				});
 			}
 		} else {
-			const age = t.profileAge;
 			profiles.push({
 				id: t.id,
 				type: "user_profile",
 				count: t.count,
-				ageGroup: t.ageGroup,
-				...(age != null
-					? { minimumAge: age, maximumAge: age }
-					: {
-							...(t.minAge != null ? { minimumAge: t.minAge } : {}),
-							...(t.maxAge != null ? { maximumAge: t.maxAge } : {}),
-						}),
+				...(profileAgeGroup != null ? { ageGroup: profileAgeGroup } : {}),
+				...(t.minAge != null ? { minimumAge: t.minAge } : {}),
+				...(t.maxAge != null ? { maximumAge: t.maxAge } : {}),
 				...entitlements,
 			});
 		}

--- a/clients/tanstack-start/src/routes/index.tsx
+++ b/clients/tanstack-start/src/routes/index.tsx
@@ -11,7 +11,7 @@ import { SearchFormProvider, useSearchForm } from "../context/search-form";
 import { useSearchOffers } from "../hooks/use-search-offers";
 import { useTripPlanner } from "../hooks/use-trip-planner";
 import { writeSearchSession } from "../lib/search-session";
-import type { TripPatternLeg, UserProfile } from "../types/search";
+import type { IndividualTraveller, TripPatternLeg, UserProfile } from "../types/search";
 import type { TripPattern } from "../types/trip-planner";
 
 export const Route = createFileRoute("/")({ component: SearchPage });
@@ -24,15 +24,61 @@ function SearchPage() {
 	);
 }
 
-function buildProfiles(travelers: TravelerGroup[]): UserProfile[] {
-	return travelers.map((t) => ({
-		id: t.id,
-		type: "user_profile" as const,
-		count: t.count,
-		ageGroup: t.ageGroup.toLowerCase() as UserProfile["ageGroup"],
-		...(t.minAge != null ? { minimumAge: t.minAge } : {}),
-		...(t.maxAge != null ? { maximumAge: t.maxAge } : {}),
-	}));
+function buildRequest(travelers: TravelerGroup[]): {
+	profiles: UserProfile[];
+	travellers: IndividualTraveller[];
+} {
+	const profiles: UserProfile[] = [];
+	const travellers: IndividualTraveller[] = [];
+
+	for (const t of travelers) {
+		const entitlements = t.entitlement
+			? { entitlements: { entitlementsGiven: [{ entitlementType: t.entitlement }] } }
+			: {};
+
+		const named = t.individuals?.filter((i) => i.name || i.age != null) ?? [];
+
+		if (named.length > 0) {
+			named.forEach((person, j) => {
+				travellers.push({
+					id: `${t.id}_${j}`,
+					type: "individual_traveller",
+					...(person.age != null ? { age: person.age } : {}),
+					...(person.name ? { fullName: person.name } : {}),
+					...entitlements,
+				});
+			});
+			const unnamedCount = t.count - named.length;
+			if (unnamedCount > 0) {
+				profiles.push({
+					id: `${t.id}_anon`,
+					type: "user_profile",
+					count: unnamedCount,
+					ageGroup: t.ageGroup.toLowerCase() as UserProfile["ageGroup"],
+					...(t.minAge != null ? { minimumAge: t.minAge } : {}),
+					...(t.maxAge != null ? { maximumAge: t.maxAge } : {}),
+					...entitlements,
+				});
+			}
+		} else {
+			const age = t.profileAge;
+			profiles.push({
+				id: t.id,
+				type: "user_profile",
+				count: t.count,
+				ageGroup: t.ageGroup.toLowerCase() as UserProfile["ageGroup"],
+				...(age != null
+					? { minimumAge: age, maximumAge: age }
+					: {
+							...(t.minAge != null ? { minimumAge: t.minAge } : {}),
+							...(t.maxAge != null ? { maximumAge: t.maxAge } : {}),
+						}),
+				...entitlements,
+			});
+		}
+	}
+
+	return { profiles, travellers };
 }
 
 function SearchScreen() {
@@ -58,12 +104,13 @@ function SearchScreen() {
 			return;
 		}
 
-		const profiles = buildProfiles(state.travelers);
+		const { profiles, travellers } = buildRequest(state.travelers);
 
 		const result = await mutateAsync({
 			inputs: {
 				type: "search_offer",
-				profiles,
+				...(profiles.length > 0 ? { profiles } : {}),
+				...(travellers.length > 0 ? { travellers } : {}),
 				specification: {
 					from,
 					to,
@@ -78,6 +125,7 @@ function SearchScreen() {
 			travelDate,
 			searchType,
 			profiles,
+			travellers,
 		});
 		navigate({ to: "/offers" });
 	}
@@ -88,7 +136,7 @@ function SearchScreen() {
 		const to = state.to;
 		const travelDate = state.travelDate;
 		const searchType = state.searchType;
-		const profiles = buildProfiles(state.travelers);
+		const { profiles, travellers } = buildRequest(state.travelers);
 
 		const omsaPattern: TripPatternLeg[] = pattern.legs.flatMap((leg) => {
 			if (!leg.serviceJourney) return [];
@@ -109,7 +157,8 @@ function SearchScreen() {
 		const result = await mutateAsync({
 			inputs: {
 				type: "search_offer",
-				profiles,
+				...(profiles.length > 0 ? { profiles } : {}),
+				...(travellers.length > 0 ? { travellers } : {}),
 				pattern: omsaPattern,
 			},
 		});
@@ -120,6 +169,7 @@ function SearchScreen() {
 			travelDate,
 			searchType,
 			profiles,
+			travellers,
 		});
 		navigate({ to: "/offers" });
 	}

--- a/clients/tanstack-start/src/routes/offers.tsx
+++ b/clients/tanstack-start/src/routes/offers.tsx
@@ -29,7 +29,13 @@ export function partyLabel(p: TravelParty): string {
 		const base = AGE_GROUP_LABELS[p.ageGroup ?? "anyone"] ?? p.id;
 		return p.count && p.count > 1 ? `${base} × ${p.count}` : base;
 	}
-	return p.fullName ?? (p.age != null ? `${p.age} yrs` : p.id);
+	if (p.fullName) return p.fullName;
+	const entitlements = p.entitlements?.entitlementsGiven?.map((e) => e.entitlementType) ?? [];
+	if (entitlements.length > 0) {
+		const label = entitlements.join(", ");
+		return p.age != null ? `${label} (${p.age} yrs)` : label;
+	}
+	return p.age != null ? `${p.age} yrs` : p.id;
 }
 
 function OffersPage() {

--- a/clients/tanstack-start/src/routes/offers.tsx
+++ b/clients/tanstack-start/src/routes/offers.tsx
@@ -9,7 +9,7 @@ import PageShell from "../components/layout/PageShell";
 import Button from "../components/ui/Button";
 import { PurchaseFlowProvider } from "../context/purchase-flow";
 import { readSearchSession, type SearchContext } from "../lib/search-session";
-import type { OfferCollection, UserProfile } from "../types/search";
+import type { IndividualTraveller, OfferCollection, UserProfile } from "../types/search";
 
 export const Route = createFileRoute("/offers")({ component: OffersPage });
 
@@ -22,9 +22,14 @@ const AGE_GROUP_LABELS: Record<string, string> = {
 	anyone: "Traveller",
 };
 
-function profileLabel(p: UserProfile): string {
-	const base = AGE_GROUP_LABELS[p.ageGroup ?? "anyone"] ?? p.id;
-	return p.count && p.count > 1 ? `${base} × ${p.count}` : base;
+export type TravelParty = UserProfile | IndividualTraveller;
+
+export function partyLabel(p: TravelParty): string {
+	if (p.type === "user_profile") {
+		const base = AGE_GROUP_LABELS[p.ageGroup ?? "anyone"] ?? p.id;
+		return p.count && p.count > 1 ? `${base} × ${p.count}` : base;
+	}
+	return p.fullName ?? (p.age != null ? `${p.age} yrs` : p.id);
 }
 
 function OffersPage() {
@@ -80,7 +85,10 @@ function OffersScreen() {
 		setHydrated(true);
 	}, []);
 
-	const profiles: UserProfile[] = context?.profiles ?? [];
+	const allParties: TravelParty[] = [
+		...(context?.profiles ?? []),
+		...(context?.travellers ?? []),
+	];
 	const bundles: OfferBundle[] = buildBundles(collection?.offers ?? []);
 
 	// Detect multi-leg journeys and split bundles into tiers
@@ -225,9 +233,9 @@ function OffersScreen() {
 								{formattedDate}
 							</p>
 						)}
-						{profiles.length > 0 && (
+						{allParties.length > 0 && (
 							<div className="mt-2 flex flex-wrap gap-1.5">
-								{profiles.map((p) => (
+								{allParties.map((p) => (
 									<span
 										key={p.id}
 										className="inline-flex items-center rounded-full px-2 py-0.5 text-xs"
@@ -237,7 +245,7 @@ function OffersScreen() {
 											border: "1px solid var(--wayfare-line)",
 										}}
 									>
-										{profileLabel(p)}
+										{partyLabel(p)}
 									</span>
 								))}
 							</div>
@@ -254,7 +262,7 @@ function OffersScreen() {
 						<BundleCard
 							key={String(bundle.groupKey)}
 							bundle={bundle}
-							profiles={profiles}
+							parties={allParties}
 							selected={selectedFullKey === bundle.groupKey}
 							onSelect={() => handleSelectFull(bundle.groupKey)}
 						/>
@@ -276,7 +284,7 @@ function OffersScreen() {
 											<BundleCard
 												key={String(bundle.groupKey)}
 												bundle={bundle}
-												profiles={profiles}
+												parties={allParties}
 												selected={
 													canMixAndMatch
 														? selectedLegKeys[seq] === bundle.groupKey

--- a/clients/tanstack-start/src/routes/offers.tsx
+++ b/clients/tanstack-start/src/routes/offers.tsx
@@ -14,12 +14,12 @@ import type { IndividualTraveller, OfferCollection, UserProfile } from "../types
 export const Route = createFileRoute("/offers")({ component: OffersPage });
 
 const AGE_GROUP_LABELS: Record<string, string> = {
-	adult: "Adult",
-	child: "Child",
-	youth: "Youth",
-	senior: "Senior",
-	infant: "Infant",
-	anyone: "Traveller",
+	ADULT: "Adult",
+	CHILD: "Child",
+	YOUTH: "Youth",
+	SENIOR: "Senior",
+	INFANT: "Infant",
+	ANYONE: "Traveller",
 };
 
 export type TravelParty = UserProfile | IndividualTraveller;

--- a/clients/tanstack-start/src/routes/offers.tsx
+++ b/clients/tanstack-start/src/routes/offers.tsx
@@ -9,9 +9,23 @@ import PageShell from "../components/layout/PageShell";
 import Button from "../components/ui/Button";
 import { PurchaseFlowProvider } from "../context/purchase-flow";
 import { readSearchSession, type SearchContext } from "../lib/search-session";
-import type { IndividualTraveller, OfferCollection } from "../types/search";
+import type { OfferCollection, UserProfile } from "../types/search";
 
 export const Route = createFileRoute("/offers")({ component: OffersPage });
+
+const AGE_GROUP_LABELS: Record<string, string> = {
+	adult: "Adult",
+	child: "Child",
+	youth: "Youth",
+	senior: "Senior",
+	infant: "Infant",
+	anyone: "Traveller",
+};
+
+function profileLabel(p: UserProfile): string {
+	const base = AGE_GROUP_LABELS[p.ageGroup ?? "anyone"] ?? p.id;
+	return p.count && p.count > 1 ? `${base} × ${p.count}` : base;
+}
 
 function OffersPage() {
 	return (
@@ -66,7 +80,7 @@ function OffersScreen() {
 		setHydrated(true);
 	}, []);
 
-	const travellers: IndividualTraveller[] = context?.travellers ?? [];
+	const profiles: UserProfile[] = context?.profiles ?? [];
 	const bundles: OfferBundle[] = buildBundles(collection?.offers ?? []);
 
 	// Detect multi-leg journeys and split bundles into tiers
@@ -211,11 +225,11 @@ function OffersScreen() {
 								{formattedDate}
 							</p>
 						)}
-						{travellers.length > 0 && (
+						{profiles.length > 0 && (
 							<div className="mt-2 flex flex-wrap gap-1.5">
-								{travellers.map((t) => (
+								{profiles.map((p) => (
 									<span
-										key={t.id}
+										key={p.id}
 										className="inline-flex items-center rounded-full px-2 py-0.5 text-xs"
 										style={{
 											background: "var(--wayfare-bg)",
@@ -223,7 +237,7 @@ function OffersScreen() {
 											border: "1px solid var(--wayfare-line)",
 										}}
 									>
-										{t.age != null ? `${t.age} yrs` : t.id}
+										{profileLabel(p)}
 									</span>
 								))}
 							</div>
@@ -240,7 +254,7 @@ function OffersScreen() {
 						<BundleCard
 							key={String(bundle.groupKey)}
 							bundle={bundle}
-							travellers={travellers}
+							profiles={profiles}
 							selected={selectedFullKey === bundle.groupKey}
 							onSelect={() => handleSelectFull(bundle.groupKey)}
 						/>
@@ -262,7 +276,7 @@ function OffersScreen() {
 											<BundleCard
 												key={String(bundle.groupKey)}
 												bundle={bundle}
-												travellers={travellers}
+												profiles={profiles}
 												selected={
 													canMixAndMatch
 														? selectedLegKeys[seq] === bundle.groupKey

--- a/clients/tanstack-start/src/routes/offers.tsx
+++ b/clients/tanstack-start/src/routes/offers.tsx
@@ -9,34 +9,12 @@ import PageShell from "../components/layout/PageShell";
 import Button from "../components/ui/Button";
 import { PurchaseFlowProvider } from "../context/purchase-flow";
 import { readSearchSession, type SearchContext } from "../lib/search-session";
-import type { IndividualTraveller, OfferCollection, UserProfile } from "../types/search";
+import { partyLabel, type TravelParty } from "../lib/travel-party";
+import type { OfferCollection } from "../types/search";
+
+export type { TravelParty };
 
 export const Route = createFileRoute("/offers")({ component: OffersPage });
-
-const AGE_GROUP_LABELS: Record<string, string> = {
-	ADULT: "Adult",
-	CHILD: "Child",
-	YOUTH: "Youth",
-	SENIOR: "Senior",
-	INFANT: "Infant",
-	ANYONE: "Traveller",
-};
-
-export type TravelParty = UserProfile | IndividualTraveller;
-
-export function partyLabel(p: TravelParty): string {
-	if (p.type === "user_profile") {
-		const base = AGE_GROUP_LABELS[p.ageGroup ?? "anyone"] ?? p.id;
-		return p.count && p.count > 1 ? `${base} × ${p.count}` : base;
-	}
-	if (p.fullName) return p.fullName;
-	const entitlements = p.entitlements?.entitlementsGiven?.map((e) => e.entitlementType) ?? [];
-	if (entitlements.length > 0) {
-		const label = entitlements.join(", ");
-		return p.age != null ? `${label} (${p.age} yrs)` : label;
-	}
-	return p.age != null ? `${p.age} yrs` : p.id;
-}
 
 function OffersPage() {
 	return (

--- a/clients/tanstack-start/src/types/search.ts
+++ b/clients/tanstack-start/src/types/search.ts
@@ -8,7 +8,7 @@ export interface TripPatternLeg {
 }
 
 interface TravelPartyEntitlements {
-	entitlementsGiven?: { entitlementType: string }[];
+	entitlementsGiven?: { type: "entitlement"; entitlementType: string }[];
 }
 
 export interface IndividualTraveller {

--- a/clients/tanstack-start/src/types/search.ts
+++ b/clients/tanstack-start/src/types/search.ts
@@ -23,7 +23,7 @@ export interface UserProfile {
 	id: string;
 	type: "user_profile";
 	count?: number;
-	ageGroup?: "anyone" | "infant" | "child" | "youth" | "adult" | "senior";
+	ageGroup?: "ANYONE" | "INFANT" | "CHILD" | "YOUTH" | "ADULT" | "SENIOR";
 	minimumAge?: number;
 	maximumAge?: number;
 	entitlements?: TravelPartyEntitlements;

--- a/clients/tanstack-start/src/types/search.ts
+++ b/clients/tanstack-start/src/types/search.ts
@@ -17,7 +17,7 @@ export interface UserProfile {
 	id: string;
 	type: "user_profile";
 	count?: number;
-	ageGroup?: "ANYONE" | "INFANT" | "CHILD" | "YOUTH" | "ADULT" | "SENIOR";
+	ageGroup?: "anyone" | "infant" | "child" | "youth" | "adult" | "senior";
 	minimumAge?: number;
 	maximumAge?: number;
 }

--- a/clients/tanstack-start/src/types/search.ts
+++ b/clients/tanstack-start/src/types/search.ts
@@ -7,10 +7,16 @@ export interface TripPatternLeg {
 	to?: PlaceReference;
 }
 
+interface TravelPartyEntitlements {
+	entitlementsGiven?: { entitlementType: string }[];
+}
+
 export interface IndividualTraveller {
 	id: string;
 	type: "individual_traveller";
 	age?: number;
+	fullName?: string;
+	entitlements?: TravelPartyEntitlements;
 }
 
 export interface UserProfile {
@@ -20,6 +26,7 @@ export interface UserProfile {
 	ageGroup?: "anyone" | "infant" | "child" | "youth" | "adult" | "senior";
 	minimumAge?: number;
 	maximumAge?: number;
+	entitlements?: TravelPartyEntitlements;
 }
 
 export interface SearchSpecification {


### PR DESCRIPTION
Adds support for named travellers (STUDENT, MILITARY) in the TanStack Start client.

- Search form accepts named travellers with entitlement types
- Entitlement objects now include the required `type: "entitlement"` discriminator field
- Traveller labels show entitlement type, e.g. "STUDENT (22 yrs)" instead of "22 yrs"
- Minor: suppress hydration warning on Button